### PR TITLE
01 calendar UI) カレンダーUIの実装

### DIFF
--- a/front/src/components/CalendarElement/index.jsx
+++ b/front/src/components/CalendarElement/index.jsx
@@ -6,21 +6,18 @@ import { Typography } from "@material-ui/core"
 
 import dayjs from "dayjs";
 
+import { isSameMonth, isFirstDay, isSameDay } from "../../services/calendar";
+
 const CalendarElement = ({ day }) => {
-  const isFirstDay = day.date() === 1;
-  const format = isFirstDay ? "M月D日" : "D";
-  
-  // 今日に青丸表示
   const today = dayjs();
-  const compareFormat = "YYYYMMDD";
-  const isToday = day.format(compareFormat) === today.format(compareFormat);
-  
-  // 今月以外をグレーダウン
-  const isCurrentMonth = day.month() === today.month();
+
+  const isCurrentMonth = isSameMonth(day, today);
   const textColor = isCurrentMonth ? "textPrimary" : "textSecondary";
 
+  const format = isFirstDay(day) ? "M月D日" : "D";
 
-
+  const isToday = isSameDay(day, today);
+  
   return(
     <div className={styles.element}>
       <Typography

--- a/front/src/components/CalendarElement/index.jsx
+++ b/front/src/components/CalendarElement/index.jsx
@@ -2,10 +2,21 @@ import React from "react";
 
 import * as styles from "./style.css";
 
-const CalendarElement = ({ children }) => {
+import { Typography } from "@material-ui/core"
+
+const CalendarElement = ({ day }) => {
+  const isFirstDay = day.date() === 1;
+  const format = isFirstDay ? "M月D日" : "D";
   return(
     <div className={styles.element}>
-      <div className={styles.date}>{ children }</div>
+      <Typography
+        className={styles.date}
+        align="center"
+        variant="caption"
+        component="div"
+      >
+        {day.format(format)}
+      </Typography>
     </div>
   );
 };

--- a/front/src/components/CalendarElement/index.jsx
+++ b/front/src/components/CalendarElement/index.jsx
@@ -4,9 +4,16 @@ import * as styles from "./style.css";
 
 import { Typography } from "@material-ui/core"
 
+import dayjs from "dayjs";
+
 const CalendarElement = ({ day }) => {
   const isFirstDay = day.date() === 1;
   const format = isFirstDay ? "M月D日" : "D";
+
+  const today = dayjs();
+  const compareFormat = "YYYYMMDD";
+  const isToday = day.format(compareFormat) === today.format(compareFormat);
+
   return(
     <div className={styles.element}>
       <Typography
@@ -15,7 +22,9 @@ const CalendarElement = ({ day }) => {
         variant="caption"
         component="div"
       >
-        {day.format(format)}
+        <span className={isToday ? styles.today : ""}>
+          {day.format(format)}
+        </span>
       </Typography>
     </div>
   );

--- a/front/src/components/CalendarElement/index.jsx
+++ b/front/src/components/CalendarElement/index.jsx
@@ -9,15 +9,23 @@ import dayjs from "dayjs";
 const CalendarElement = ({ day }) => {
   const isFirstDay = day.date() === 1;
   const format = isFirstDay ? "M月D日" : "D";
-
+  
+  // 今日に青丸表示
   const today = dayjs();
   const compareFormat = "YYYYMMDD";
   const isToday = day.format(compareFormat) === today.format(compareFormat);
+  
+  // 今月以外をグレーダウン
+  const isCurrentMonth = day.month() === today.month();
+  const textColor = isCurrentMonth ? "textPrimary" : "textSecondary";
+
+
 
   return(
     <div className={styles.element}>
       <Typography
         className={styles.date}
+        color={textColor}
         align="center"
         variant="caption"
         component="div"

--- a/front/src/components/CalendarElement/style.css
+++ b/front/src/components/CalendarElement/style.css
@@ -3,3 +3,7 @@
   border-bottom: 1px solid #ccc;
   height: 18vh;
 }
+.date {
+  padding: 5px 0;
+  height: 24px;
+}

--- a/front/src/components/CalendarElement/style.css
+++ b/front/src/components/CalendarElement/style.css
@@ -7,3 +7,11 @@
   padding: 5px 0;
   height: 24px;
 }
+.today {
+  display: inline-block;
+  line-height: 24px;
+  width: 24px;
+  background-color: #1a73e8;
+  color: #fff;
+  border-radius: 50%;
+}

--- a/front/src/components/CalenderBoard/index.jsx
+++ b/front/src/components/CalenderBoard/index.jsx
@@ -1,21 +1,34 @@
 import React from "react";
 import CalendarElement from "../CalendarElement";
 
-import { GridList } from "@material-ui/core";
+import { GridList, Typography } from "@material-ui/core";
 import { createCalendar } from "../../services/calendar";
 
 import * as styles from "./style.css";
 
 const calendar = createCalendar();
+const days = ["日", "月", "火", "水", "木", "金", "土"];
 
 const CalendarBoard = () => {
-  console.log(calendar);
   return (
     <div className={styles.container}>
       <GridList className={styles.grid} cols={7} spacing={0} cellHeight="auto">
+        {days.map(d => (
+          <li key={d}>
+            <Typography
+              className={styles.days}
+              color="textSecondary"
+              align="center"
+              variant="caption"
+              component="div"
+            >
+              {d}
+            </Typography>
+          </li>
+        ))}
         {calendar.map(c => (
           <li key={c.toISOString()}>
-            <CalendarElement>{c.format("D")}</CalendarElement>
+            <CalendarElement day={c} />
           </li>
         ))}
       </GridList>

--- a/front/src/components/CalenderBoard/style.css
+++ b/front/src/components/CalenderBoard/style.css
@@ -5,3 +5,7 @@
   border-left: 1px solid #ccc;
   border-top: 1px solid #ccc;
 }
+.days {
+  border-right: 1px solid #ccc;
+  padding-top: 10px;
+}

--- a/front/src/services/calendar.js
+++ b/front/src/services/calendar.js
@@ -12,3 +12,15 @@ export const createCalendar = () => {
       return day;
     });
 };
+
+export const isSameDay = (d1, d2) => {
+  const format = "YYYYMMDD";
+  return d1.format(format) === d2.format(format);
+};
+
+export const isSameMonth = (m1, m2) => {
+  const format = "YYYYMM";
+  return m1.format(format) === m2.format(format);
+};
+
+export const isFirstDay = day => day.date() === 1;


### PR DESCRIPTION
## 曜日の表示
・曜日の表示
  ・```const days = ["日", "月", "火", "水", "木", "金", "土"];```を使用
・曜日のスタイル設定  
  ・```<Typography>```を使用
## 月日表記
・月の初日だけに```”M月D日”```表記
## オプション表示機能

### 今日の日付に青丸
今日の日付の欄に青丸を表示する
``` <span className={isToday ? styles.today : ""}>```で
今日の日付の```{day}```には
```today```スタイルを割り当て

``` css
.today {
  display: inline-block;
  line-height: 24px;
  width: 24px;
  background-color: #1a73e8;
  color: #fff;
  border-radius: 50%;
}
```

### グレーダウン表示
・今月は黒字表記、今月以外は灰色文字表記（グレーダウン）
#### 定数の定義
```const textColor```を```isCurrentMonth```で条件分岐  
``` javascript
const isCurrentMonth = isSameMonth(day, today);
const textColor = isCurrentMonth ? "textPrimary" : "textSecondary";
```
``` jsx
<Typography
        className={styles.date}
        color={textColor}
        align="center"
        variant="caption"
        component="div"
      >
        <span className={isToday ? styles.today : ""}>
          {day.format(format)}
        </span>
</Typography>
```

## ロジックは ```services/calender.js```に集約（リファクタリング）
```const isSameDay```  
```const isSameMonth```  
```const isFirstDay```  


